### PR TITLE
Change default language and fallback to EN - #16

### DIFF
--- a/src/app/[locale]/docs/[[...slug]]/page.tsx
+++ b/src/app/[locale]/docs/[[...slug]]/page.tsx
@@ -48,9 +48,9 @@ export async function generateMetadata({
   }
 
   const slugPath = (slug || ["intro"]).join("/");
-  const currentUrl = locale === "en"
-    ? `${BASE_URL}/docs/${slugPath}`
-    : `${BASE_URL}/${locale}/docs/${slugPath}`;
+  const currentUrl = locale !== "en"
+    ? `${BASE_URL}/${locale}/docs/${slugPath}`
+    : `${BASE_URL}/docs/${slugPath}`;
 
   return {
     title: doc.meta.title,

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -42,7 +42,7 @@ function getCacheKey(query: string, locale: string): string {
   return `${locale}:${query.toLowerCase().trim()}`;
 }
 
-function getAllDocs(locale: string = "fr"): SearchResult[] {
+function getAllDocs(locale: string = "en"): SearchResult[] {
   // Check cache first
   const cached = docsCache.get(locale);
   if (isCacheValid(cached)) {
@@ -136,7 +136,7 @@ function getAllDocs(locale: string = "fr"): SearchResult[] {
   return results;
 }
 
-function searchDocs(query: string, locale: string = "fr"): SearchResult[] {
+function searchDocs(query: string, locale: string = "en"): SearchResult[] {
   // Check search cache first
   const cacheKey = getCacheKey(query, locale);
   const cached = searchCache.get(cacheKey);
@@ -211,7 +211,7 @@ function searchDocs(query: string, locale: string = "fr"): SearchResult[] {
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const query = searchParams.get("q");
-  const locale = searchParams.get("locale") || "fr";
+  const locale = searchParams.get("locale") || "en";
 
   if (!query || query.trim().length === 0) {
     return NextResponse.json(

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -17,11 +17,11 @@ export interface Doc {
   content: string;
 }
 
-function getDocsDirectory(locale: string = "fr"): string {
+function getDocsDirectory(locale: string = "en"): string {
   return path.join(contentDirectory, locale);
 }
 
-export function getDocBySlug(slug: string[], locale: string = "fr"): Doc | null {
+export function getDocBySlug(slug: string[], locale: string = "en"): Doc | null {
   const docsDirectory = getDocsDirectory(locale);
   const slugPath = slug.join("/");
 
@@ -44,9 +44,9 @@ export function getDocBySlug(slug: string[], locale: string = "fr"): Doc | null 
   }
 
   if (!filePath) {
-    // Fallback to French if not found in current locale
-    if (locale !== "fr") {
-      return getDocBySlug(slug, "fr");
+    // Fallback to English if not found in current locale
+    if (locale !== "en") {
+      return getDocBySlug(slug, "en");
     }
     return null;
   }
@@ -66,7 +66,7 @@ export function getDocBySlug(slug: string[], locale: string = "fr"): Doc | null 
   };
 }
 
-export function getAllDocSlugs(locale: string = "fr"): string[][] {
+export function getAllDocSlugs(locale: string = "en"): string[][] {
   const docsDirectory = getDocsDirectory(locale);
   const slugs: string[][] = [];
 
@@ -102,7 +102,7 @@ export function getAllDocSlugs(locale: string = "fr"): string[][] {
 
 export function getDocNavigation(
   currentSlug: string[],
-  locale: string = "fr"
+  locale: string = "en"
 ): {
   prev: { title: string; href: string } | null;
   next: { title: string; href: string } | null;


### PR DESCRIPTION
Since repo is configured with default EN and localeprefix as-needed, we need to have fallback to english instead of french.

/src/i18n/routing.ts
```ts
export const routing = defineRouting({
  locales: ['en', 'fr'],
  defaultLocale: 'en',
  localePrefix: 'as-needed',
});
```