### PR TITLE
Fix css targetting hover state globally, hover colours and some minor UI cosmetics

### DIFF
--- a/src/app/[locale]/docs/[[...slug]]/page.tsx
+++ b/src/app/[locale]/docs/[[...slug]]/page.tsx
@@ -126,108 +126,108 @@ export default async function DocPage({ params }: DocPageProps) {
       isNonFunctional={verificationStatus.nonFunctional}
       isEventPage={verificationStatus.isEventPage}
     >
-    <TocProvider items={tocItems}>
-      <div className="flex gap-8">
-        <article id="main-content" className="flex-1 min-w-0 pb-6 lg:pb-8">
-        {/* Structured Data */}
-        <BreadcrumbJsonLd items={breadcrumbItems} />
-        <ArticleJsonLd
-          title={doc.meta.title}
-          description={doc.meta.description || ""}
-          url={articleUrl}
-        />
+      <TocProvider items={tocItems}>
+        <div className="flex gap-8">
+          <article id="main-content" className="flex-1 min-w-0 pb-6 lg:pb-8">
+            {/* Structured Data */}
+            <BreadcrumbJsonLd items={breadcrumbItems} />
+            <ArticleJsonLd
+              title={doc.meta.title}
+              description={doc.meta.description || ""}
+              url={articleUrl}
+            />
 
-        {/* Breadcrumb */}
-        <div className="mb-8">
-          <DocsBreadcrumb items={visualBreadcrumbItems} />
-        </div>
+            {/* Breadcrumb */}
+            <div className="mb-8">
+              <DocsBreadcrumb items={visualBreadcrumbItems} />
+            </div>
 
-        {/* Title */}
-        <h1 className="text-4xl font-bold tracking-tight text-gradient mb-4">
-          {doc.meta.title}
-        </h1>
+            {/* Title */}
+            <h1 className="text-4xl font-bold tracking-tight text-gradient mb-4">
+              {doc.meta.title}
+            </h1>
 
-        {doc.meta.description && (
-          <p className="text-lg text-muted-foreground mb-10 leading-relaxed">
-            {doc.meta.description}
-          </p>
-        )}
+            {doc.meta.description && (
+              <p className="text-lg text-muted-foreground mb-10 leading-relaxed">
+                {doc.meta.description}
+              </p>
+            )}
 
-        {/* Separator */}
-        <div className="h-px bg-gradient-to-r from-primary/50 via-border to-transparent mb-10" />
+            {/* Separator */}
+            <div className="h-px bg-linear-to-r from-primary/50 via-border to-transparent mb-10" />
 
-        {/* Content */}
-        <div className="prose prose-slate dark:prose-invert max-w-none">
-          <MDXRemote
-            source={doc.content}
-            components={localizedMdxComponents}
-            options={{
-              mdxOptions: {
-                remarkPlugins: [remarkGfm, remarkAdmonitions],
-                rehypePlugins: [rehypeSlug, [rehypePrismPlus, { ignoreMissing: true }]],
-              },
-            }}
-          />
-        </div>
+            {/* Content */}
+            <div className="prose prose-slate dark:prose-invert max-w-none">
+              <MDXRemote
+                source={doc.content}
+                components={localizedMdxComponents}
+                options={{
+                  mdxOptions: {
+                    remarkPlugins: [remarkGfm, remarkAdmonitions],
+                    rehypePlugins: [rehypeSlug, [rehypePrismPlus, { ignoreMissing: true }]],
+                  },
+                }}
+              />
+            </div>
 
-        {/* Discrete ad after content */}
-        <ArticleAd />
+            {/* Discrete ad after content */}
+            <ArticleAd />
 
-        {/* Navigation */}
-        <div className="h-px bg-gradient-to-r from-transparent via-border to-transparent my-12" />
+            {/* Navigation */}
+            <div className="h-px bg-linear-to-r from-transparent via-border to-transparent my-12" />
 
-        <nav className="flex items-stretch gap-4">
-          {prev ? (
-            <Link
-              href={prev.href}
-              className="flex-1 group p-5 rounded-xl border-2 border-border bg-card/30 transition-all duration-300 hover:border-secondary/50 hover:bg-card/50"
-            >
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-secondary/10 transition-colors group-hover:bg-secondary/20">
-                  <ChevronLeft className="h-5 w-5 text-secondary" />
-                </div>
-                <div>
-                  <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">{t("previous")}</div>
-                  <div className="font-semibold text-foreground group-hover:text-secondary transition-colors">
-                    {prev.title}
+            <nav className="flex items-stretch gap-4">
+              {prev ? (
+                <Link
+                  href={prev.href}
+                  className="flex-1 group p-5 rounded-xl border-2 border-border bg-card/30 transition-all duration-300 hover:border-secondary/50 hover:bg-card/50"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-secondary/10 transition-colors group-hover:bg-secondary/20">
+                      <ChevronLeft className="h-5 w-5 text-secondary" />
+                    </div>
+                    <div>
+                      <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">{t("previous")}</div>
+                      <div className="font-semibold text-foreground group-hover:text-secondary transition-colors">
+                        {prev.title}
+                      </div>
+                    </div>
                   </div>
-                </div>
-              </div>
-            </Link>
-          ) : (
-            <div className="flex-1" />
-          )}
+                </Link>
+              ) : (
+                <div className="flex-1" />
+              )}
 
-          {next ? (
-            <Link
-              href={next.href}
-              className="flex-1 group p-5 rounded-xl border-2 border-border bg-card/30 transition-all duration-300 hover:border-primary/50 hover:bg-card/50"
-            >
-              <div className="flex items-center justify-end gap-3">
-                <div className="text-right">
-                  <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">{t("next")}</div>
-                  <div className="font-semibold text-foreground group-hover:text-primary transition-colors">
-                    {next.title}
+              {next ? (
+                <Link
+                  href={next.href}
+                  className="flex-1 group p-5 rounded-xl border-2 border-border bg-card/30 transition-all duration-300 hover:border-primary/50 hover:bg-card/50"
+                >
+                  <div className="flex items-center justify-end gap-3">
+                    <div className="text-right">
+                      <div className="text-xs text-muted-foreground uppercase tracking-wide mb-1">{t("next")}</div>
+                      <div className="font-semibold text-foreground group-hover:text-primary transition-colors">
+                        {next.title}
+                      </div>
+                    </div>
+                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 transition-colors group-hover:bg-primary/20">
+                      <ChevronRight className="h-5 w-5 text-primary" />
+                    </div>
                   </div>
-                </div>
-                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 transition-colors group-hover:bg-primary/20">
-                  <ChevronRight className="h-5 w-5 text-primary" />
-                </div>
-              </div>
-            </Link>
-          ) : (
-            <div className="flex-1" />
-          )}
-        </nav>
-      </article>
+                </Link>
+              ) : (
+                <div className="flex-1" />
+              )}
+            </nav>
+          </article>
 
-        {/* Table of Contents - Right Sidebar */}
-        <TableOfContents items={tocItems} />
+          {/* Table of Contents - Right Sidebar */}
+          <TableOfContents items={tocItems} />
 
-        {/* Back to Top Button */}
-        <BackToTop />
-      </div>
-    </TocProvider>
+          {/* Back to Top Button */}
+          <BackToTop />
+        </div>
+      </TocProvider>
     </UnverifiedContentModal>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1336,4 +1336,3 @@ pre code {
 .reading-dark::-webkit-scrollbar-thumb:hover {
   background: #d4a84b;
 }
-

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -245,15 +245,18 @@
       color var(--transition-theme) var(--ease-in-out);
   }
 
+
+  /* Again not the best idea, it's better to target the elements that need to be transitioned */
+
   /* Transition for all themed elements (colors) */
-  *:not(pre):not(code):not(.no-transition) {
-    transition:
-      background-color var(--transition-theme) var(--ease-in-out),
-      border-color var(--transition-theme) var(--ease-in-out),
-      color var(--transition-normal) var(--ease-in-out),
-      fill var(--transition-theme) var(--ease-in-out),
-      stroke var(--transition-theme) var(--ease-in-out);
-  }
+  /* *:not(pre):not(code):not(.no-transition) { */
+  /*   transition: */
+  /*     background-color var(--transition-theme) var(--ease-in-out), */
+  /*     border-color var(--transition-theme) var(--ease-in-out), */
+  /*     color var(--transition-normal) var(--ease-in-out), */
+  /*     fill var(--transition-theme) var(--ease-in-out), */
+  /*     stroke var(--transition-theme) var(--ease-in-out); */
+  /* } */
 
   /* Interactive elements - faster hover response */
   a,
@@ -262,7 +265,8 @@
   input,
   select,
   textarea,
-  [class*="hover:"],
+  /* Globally targetting hover class is not the best approach, especially with radix primitives. That's the reason why hover and colours were messed up on the hover */
+  /* [class*="hover:"], */
   [class*="focus:"] {
     transition:
       background-color var(--transition-normal) var(--ease-out),

--- a/src/components/layout/theme-toggle.tsx
+++ b/src/components/layout/theme-toggle.tsx
@@ -63,25 +63,43 @@ export function ThemeToggle({
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="w-56 ">
           <DropdownMenuItem onClick={() => setTheme("light")} className="gap-2 group text-muted-foreground">
-            <Sun className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
+            <Sun className={cn(
+              "h-4 w-4",
+              theme === "dark" || theme === "reading-dark" ? "group-hover:text-black" : "group-hover:text-black"
+            )} />
             Light
           </DropdownMenuItem>
           <DropdownMenuItem onClick={() => setTheme("dark")} className="gap-2 group text-muted-foreground">
-            <Moon className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
+            <Moon className={cn(
+              "h-4 w-4",
+              theme === "dark" || theme === "reading-dark" ? "group-hover:text-black" : "group-hover:text-black"
+            )} />
             Dark
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={() => setTheme("reading")} className="gap-2 group text-muted-foreground">
-            <BookOpen className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
+            <BookOpen className={cn(
+              "h-4 w-4",
+              theme === "dark" || theme === "reading-dark" ? "group-hover:text-black" : "group-hover:text-black"
+            )} />
+
             Reading Light
           </DropdownMenuItem>
           <DropdownMenuItem onClick={() => setTheme("reading-dark")} className="gap-2 group text-muted-foreground">
-            <BookMarked className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
+            <BookMarked className={cn(
+              "h-4 w-4",
+              theme === "dark" || theme === "reading-dark" ? "group-hover:text-black" : "group-hover:text-black"
+            )} />
+
             Reading Dark
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={() => setTheme("system")} className="gap-2 group text-muted-foreground">
-            <Monitor className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
+            <Monitor className={cn(
+              "h-4 w-4 text-muted-foreground",
+              theme === "dark" || theme === "reading-dark" ? "group-hover:text-black" : "group-hover:text-black"
+            )} />
+
             System
           </DropdownMenuItem>
         </DropdownMenuContent>
@@ -106,26 +124,43 @@ export function ThemeToggle({
         </TooltipContent>
         <DropdownMenuContent align="end">
           <DropdownMenuItem onClick={() => setTheme("light")} className="gap-2 group text-muted-foreground">
-            {/* Icons need a base colour to not glitch during colour transition */}
-            <Sun color="currentColor" className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
+            <Sun className={cn(
+              "h-4 w-4",
+              theme === "dark" || theme === "reading-dark" ? "group-hover:text-black" : "group-hover:text-black"
+            )} />
             Light
           </DropdownMenuItem>
           <DropdownMenuItem onClick={() => setTheme("dark")} className="gap-2 group text-muted-foreground">
-            <Moon className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
+            <Moon className={cn(
+              "h-4 w-4",
+              theme === "dark" || theme === "reading-dark" ? "group-hover:text-black" : "group-hover:text-black"
+            )} />
             Dark
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={() => setTheme("reading")} className="gap-2 group text-muted-foreground">
-            <BookOpen className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
+            <BookOpen className={cn(
+              "h-4 w-4",
+              theme === "dark" || theme === "reading-dark" ? "group-hover:text-black" : "group-hover:text-black"
+            )} />
+
             Reading Light
           </DropdownMenuItem>
           <DropdownMenuItem onClick={() => setTheme("reading-dark")} className="gap-2 group text-muted-foreground">
-            <BookMarked className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
+            <BookMarked className={cn(
+              "h-4 w-4",
+              theme === "dark" || theme === "reading-dark" ? "group-hover:text-black" : "group-hover:text-black"
+            )} />
+
             Reading Dark
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={() => setTheme("system")} className="gap-2 group text-muted-foreground">
-            <Monitor className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
+            <Monitor className={cn(
+              "h-4 w-4",
+              theme === "dark" || theme === "reading-dark" ? "group-hover:text-black" : "group-hover:text-black"
+            )} />
+
             System
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/src/components/layout/theme-toggle.tsx
+++ b/src/components/layout/theme-toggle.tsx
@@ -61,27 +61,27 @@ export function ThemeToggle({
         <DropdownMenuTrigger asChild>
           {trigger}
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-56">
-          <DropdownMenuItem onClick={() => setTheme("light")} className="gap-2">
-            <Sun className="h-4 w-4" />
+        <DropdownMenuContent align="start" className="w-56 ">
+          <DropdownMenuItem onClick={() => setTheme("light")} className="gap-2 group text-muted-foreground">
+            <Sun className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
             Light
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => setTheme("dark")} className="gap-2">
-            <Moon className="h-4 w-4" />
+          <DropdownMenuItem onClick={() => setTheme("dark")} className="gap-2 group text-muted-foreground">
+            <Moon className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
             Dark
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => setTheme("reading")} className="gap-2">
-            <BookOpen className="h-4 w-4" />
+          <DropdownMenuItem onClick={() => setTheme("reading")} className="gap-2 group text-muted-foreground">
+            <BookOpen className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
             Reading Light
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => setTheme("reading-dark")} className="gap-2">
-            <BookMarked className="h-4 w-4" />
+          <DropdownMenuItem onClick={() => setTheme("reading-dark")} className="gap-2 group text-muted-foreground">
+            <BookMarked className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
             Reading Dark
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => setTheme("system")} className="gap-2">
-            <Monitor className="h-4 w-4" />
+          <DropdownMenuItem onClick={() => setTheme("system")} className="gap-2 group text-muted-foreground">
+            <Monitor className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
             System
           </DropdownMenuItem>
         </DropdownMenuContent>
@@ -105,26 +105,27 @@ export function ThemeToggle({
           Change theme
         </TooltipContent>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem onClick={() => setTheme("light")} className="gap-2">
-            <Sun className="h-4 w-4" />
+          <DropdownMenuItem onClick={() => setTheme("light")} className="gap-2 group text-muted-foreground">
+            {/* Icons need a base colour to not glitch during colour transition */}
+            <Sun color="currentColor" className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
             Light
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => setTheme("dark")} className="gap-2">
-            <Moon className="h-4 w-4" />
+          <DropdownMenuItem onClick={() => setTheme("dark")} className="gap-2 group text-muted-foreground">
+            <Moon className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
             Dark
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => setTheme("reading")} className="gap-2">
-            <BookOpen className="h-4 w-4" />
+          <DropdownMenuItem onClick={() => setTheme("reading")} className="gap-2 group text-muted-foreground">
+            <BookOpen className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
             Reading Light
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => setTheme("reading-dark")} className="gap-2">
-            <BookMarked className="h-4 w-4" />
+          <DropdownMenuItem onClick={() => setTheme("reading-dark")} className="gap-2 group text-muted-foreground">
+            <BookMarked className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
             Reading Dark
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => setTheme("system")} className="gap-2">
-            <Monitor className="h-4 w-4" />
+          <DropdownMenuItem onClick={() => setTheme("system")} className="gap-2 group text-muted-foreground">
+            <Monitor className="h-4 w-4 text-muted-foreground group-hover:text-white dark:group-hover:text-black" />
             System
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/src/components/reading-mode-toggle.tsx
+++ b/src/components/reading-mode-toggle.tsx
@@ -10,6 +10,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
 
 export function ReadingModeToggle() {
   const { theme, setTheme } = useTheme();
@@ -25,17 +26,6 @@ export function ReadingModeToggle() {
   }
 
   const isReadingMode = theme === "reading" || theme === "reading-dark";
-
-  // Determine the base theme (light or dark) to return to
-  const getBaseTheme = () => {
-    if (theme === "reading") return "light";
-    if (theme === "reading-dark") return "dark";
-    // If in light mode, check system preference for dark
-    if (theme === "light") return "light";
-    if (theme === "dark") return "dark";
-    // For system theme, we'll default to dark reading
-    return "dark";
-  };
 
   const toggleReadingMode = () => {
     if (isReadingMode) {
@@ -63,15 +53,14 @@ export function ReadingModeToggle() {
             variant="outline"
             size="icon"
             onClick={toggleReadingMode}
-            className={`
-              fixed bottom-6 left-6 z-50
+            className={cn(
+              `fixed bottom-6 left-6 z-50
+              cursor-pointer
               h-12 w-12 rounded-full shadow-lg
-              transition-all duration-300
-              ${isReadingMode
-                ? "bg-primary text-primary-foreground hover:bg-primary/90 border-primary"
-                : "bg-card hover:bg-muted border-border"
-              }
-            `}
+              transition-all duration-300`,
+              isReadingMode ? "bg-primary text-primary-foreground hover:bg-primary/90 border-primary" : "bg-card hover:bg-muted border-border",
+              theme === "dark" ? "hover:text-muted-foreground" : "hover:text-gray-600"
+            )}
             aria-label={isReadingMode ? "Exit reading mode" : "Enter reading mode"}
           >
             {isReadingMode ? (

--- a/src/components/reading-mode-toggle.tsx
+++ b/src/components/reading-mode-toggle.tsx
@@ -16,15 +16,16 @@ export function ReadingModeToggle() {
   const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
+
   // Avoid hydration mismatch
   useEffect(() => {
     setMounted(true);
   }, []);
 
+
   if (!mounted) {
     return null;
   }
-
   const isReadingMode = theme === "reading" || theme === "reading-dark";
 
   const toggleReadingMode = () => {
@@ -45,6 +46,7 @@ export function ReadingModeToggle() {
     }
   };
 
+
   return (
     <TooltipProvider>
       <Tooltip>
@@ -54,12 +56,12 @@ export function ReadingModeToggle() {
             size="icon"
             onClick={toggleReadingMode}
             className={cn(
-              `fixed bottom-6 left-6 z-50
+              `fixed bottom-18 lg:bottom-6 left-6 z-50
               cursor-pointer
               h-12 w-12 rounded-full shadow-lg
               transition-all duration-300`,
               isReadingMode ? "bg-primary text-primary-foreground hover:bg-primary/90 border-primary" : "bg-card hover:bg-muted border-border",
-              theme === "dark" ? "hover:text-muted-foreground" : "hover:text-gray-600"
+              theme === "dark" ? "hover:text-muted-foreground" : "hover:text-gray-600",
             )}
             aria-label={isReadingMode ? "Exit reading mode" : "Enter reading mode"}
           >


### PR DESCRIPTION
Previously theme toggle and reading-view button had a few issues with icon colours on hover. I fixed that by also removing unnecessary css that was targeting hover state globally which caused some UI bugs, mainly with off-sync transitions and issues with class hierarchy.

Before:
<img width="1149" height="618" alt="image" src="https://github.com/user-attachments/assets/ca1ee76b-e6ae-4ec2-9036-8fae154ad604" />
After:
<img width="557" height="591" alt="image" src="https://github.com/user-attachments/assets/72f43c75-e841-4c4a-9b16-122c65858d1d" />

Reading-view button on medium and small devices before:
<img width="891" height="919" alt="image" src="https://github.com/user-attachments/assets/5cf199a9-317e-4a99-b6df-403aff54ca37" />
After:
<img width="743" height="972" alt="image" src="https://github.com/user-attachments/assets/94eec41c-9bdc-48b0-8090-c42beba5deea" />


Nothing major, just a few tweaks.