### PR TITLE
Add Hytale Character Recipes

### DIFF
--- a/content/docs/en/community/resources.md
+++ b/content/docs/en/community/resources.md
@@ -27,6 +27,7 @@ A curated list of helpful resources for Hytale development.
 | HytalePlugins | [hytaleplugins.gg](https://hytaleplugins.gg) | Plugin hub |
 | HytaleHub | [hytalehub.com](https://hytalehub.com) | Community forums |
 | CurseForge | [curseforge.com/hytale](https://curseforge.com/hytale) | Mod distribution |
+| Hytale Character Recipes | [hytalecharacter.com](https://hytalecharacter.com/) | Fan-made character look recreation archive with screenshots, recipe JSON, in-game creator paths, and source notes |
 
 ## Tools
 


### PR DESCRIPTION
Adds Hytale Character Recipes to the community resources page. The site is a fan-made character look recreation archive with screenshots, recipe JSON, in-game creator paths, and source notes.